### PR TITLE
update lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataframe",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Explore data by grouping and reducing.",
   "main": "index.js",
   "directories": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/davidguttman/node-dataframe",
   "dependencies": {
-    "lodash": "^3.3.1"
+    "lodash": ">=3.3.1"
   },
   "devDependencies": {
     "sprintf-js": "^1.0.2",


### PR DESCRIPTION
I updated the lodash dependency from `^` to `>=3.3.1`.  It still passes tests and from cursory look thru the code I don't see anything that would be dependent on 3.3 vs the current 4.13.
